### PR TITLE
Add docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,59 @@
+##
+# MLH Hackathon Nodejs Starter
+# commands to run and manipulate docker environment
+##
+DKR=docker-compose
+NODE=nodejs
+
+default: help;
+
+init:	## initialize your environment from the begining, build docker stuff, install dependencies and run the watch mode.
+	${DKR} build
+	make dependencies
+	make watch
+
+watch:	## run the application in development mode with a live reload, display the status of the containers and display the logs.
+	${DKR} up -d
+	make status
+	echo ""
+	make logs
+
+run:	## run the production mode of the app, no livereload here, just launch nodejs and display the status of components.
+	${DKR} run --rm ${NODE} npm run deploy
+	make status
+
+stop:	## stop the entire application, the database data is preserved.
+	${DKR} down
+
+restart:	## restart all components (nodejs and database).
+	make stop
+	make watch
+
+dependencies:	## install (or reinstall) npm dependencies.
+	${DKR} run --rm ${NODE} npm install
+
+status:	## display status of each component, Up -> UNIX process is running. Exit -> UNIX process was killed or crash.
+	${DKR} ps
+
+logs:	## display nodejs server logs.
+	${DKR} logs -f ${NODE}
+
+command:	## launch a bash command inside your environment. example: make command cmd="npm install --save express"
+	${DKR} run --rm ${NODE} ${cmd}
+
+destroy:	## stop, clean and destroy everything. delete node_modules, destroy process and delete the entire database.
+	read -p "This command will stop your env, clean the repo and destroy the database. Did you want to continue? (y/n)" resp ; \
+	echo "" ; \
+	if [ "$$resp" = "y" ]; then \
+		${DKR} run --rm ${NODE} rm -rf ./node_modules ; ${DKR} down -v --remove-orphans ; \
+	fi
+
+help:	## display this help.
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' ${MAKEFILE_LIST} | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
+.PHONY:
+	init watch run stop restart dependencies status logs destroy
+.SILENT:
+	init watch run stop restart dependencies status logs destroy
+
+# end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3"
+
+services:
+  nodejs:
+    image: node:10.15-alpine
+    volumes:
+      - ./:/app/
+    working_dir: /app/
+    networks:
+      - public
+    ports:
+      - "5000:5000"
+      - "9042:9042"
+    environment:
+      - PORT=
+      - NODE_ENV=development
+      - SECRET_KEY=
+      - DATABASE_URL=${DATABASE_URL}
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+    command: npm run start
+
+  postgres:
+    image: postgres:11.2-alpine
+    volumes:
+      - data_db:/var/lib/postgresql/data
+    networks:
+      - public
+    ports:
+      - "5432:5432"
+
+
+networks:
+  public:
+
+volumes:
+  data_db:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -217,6 +217,63 @@ The `DATABASE_URL` variable is the path to your database system. This is where y
 
 The `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET` variables are the app credentials from your [GitHub OAuth app](https://github.com/settings/developers).
 
+## <a name='docker'>Deploy development environment with docker</a>
+
+You can easily and quickly deploy an environment with Docker containers. A
+Makefile is available with some commands to quick and easy launch.
+
+### What you need ?
+
+* a docker daemon running on your machine.
+* docker-compose tools to be able to launch the environment.
+
+### How to use.
+
+The first time you want to launch the environment, you have to initialize it
+(build stuff for docker and install the dependencies), for that just launch:
+
+```sh
+make init
+```
+
+This command will initialize and launch the entire process in watch mode.
+(Nodejs process with livereload).
+
+If your environment was already been initialized, you can just use a command to
+run the application:
+
+```sh
+make watch # run the nodejs app in development mode with a livereload.
+# OR
+make run # run the nodejs app in production mode.
+```
+
+If you want to visualize the logs of the Nodejs app:
+
+```sh
+make logs
+```
+
+If you want to switch off your environment:
+
+```sh
+make stop
+```
+
+Finally, when your work is finished and you don't need the environment at all,
+you can stop and destroy all stuff and data (node_modules and database data):
+
+```sh
+make destroy
+```
+
+**Note**: if you want advanced commands for this docker environment, consult the
+help:
+
+```sh
+make help
+```
+
 ## Deployment
 
 ### Deploy to Heroku


### PR DESCRIPTION
create a docker-compose configuration to quickly deploy a development environment. This configuration will deploy a Nodejs container with the Nodejs process running inside and a postgres container which run Postgresql process. It exposes port 5000 to the host for the Nodejs app, it exposes the port 9042 if the developer wants to connect a chrome debugger onto it. It exposes Postgresql port too for debugging.

create a Makefile to abstract docker-compose commands, so any developers can launch and basically manage this development environment.
here is the commands available in the Makefile (this is a screenshot from the `make help` command):

![help](https://user-images.githubusercontent.com/10661789/56054091-258bcb80-5d56-11e9-8203-e6c92d545ef5.png)
