### PR TITLE
Update License Link in the License Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ We enforce a Code of Conduct for all maintainers and contributors of this Guide.
 The Hackathon Starter Kit is open source software [licensed as MIT][mlh-license].
 
 [mlh-conduct]: https://github.com/MLH/mlh-hackathon-nodejs-starter/blob/master/docs/CONDUCT.md
-[mlh-license]: https://github.com/MLH/mlh-hackathon-nodejs-starter/blob/master/LICENSE.md
+[mlh-license]: https://github.com/MLH/mlh-hackathon-nodejs-starter/blob/master/LICENSE


### PR DESCRIPTION
### Summary
* Updated License section with the correct link to license. 

### Before the change :
 
![Screenshot from 2020-12-24 18-46-11](https://user-images.githubusercontent.com/40469121/103090894-6c981e00-4618-11eb-81a0-7a2e39589c9a.png)

### After the change : 
![Screenshot from 2020-12-24 18-46-31](https://user-images.githubusercontent.com/40469121/103090898-715cd200-4618-11eb-9ad8-119845b1640d.png)

fixes #21 
@mkcode 