### PR TITLE
Change to github header auth as param auth is deprecated

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -4,7 +4,7 @@ module.exports = (sequelize, DataTypes) => {
   const User = sequelize.define(
     "User",
     {
-      username: { type: DataTypes.STRING, unqiue: true, allowNull: false },
+      username: { type: DataTypes.STRING, unique: true, allowNull: false },
       avatar_url: DataTypes.STRING,
       github_id: DataTypes.STRING
     },

--- a/app/services/github.js
+++ b/app/services/github.js
@@ -30,16 +30,17 @@ class GitHub {
 
   async get(route_url, params = {}) {
     const url = api_url + route_url;
-    params["access_token"] = this.access_token;
+    const config = { headers: { Authorization: 'token ' + this.access_token }, 
+                     params: params };
 
-    const response = await axios.get(url, { params });
+    const response = await axios.get(url, config);
     return response.data;
   }
 
   static async get_user_from_token(access_token) {
     /* Fetch user data using the access token. */
     const url = api_url + "/user";
-    const config = { params: { access_token: access_token } };
+    const config = { headers: { Authorization: 'token ' + access_token } };
 
     const response = await axios.get(url, config);
     return response.data;


### PR DESCRIPTION
- Github params authentication [is deprecated](https://developer.github.com/changes/2019-11-05-deprecated-passwords-and-authorizations-api/#authenticating-using-query-parameters) so authentication method is updated to header auth
- Corrected minor spelling error for 'unique' in user.js